### PR TITLE
qubes hcl report

### DIFF
--- a/src/qubes-completion.sh
+++ b/src/qubes-completion.sh
@@ -3067,7 +3067,7 @@ function _qubes_hcl_report() {
     if (( QB_alone_args_count == 0 )); then
 
         if __need_flags ; then
-            __complete_string '--help -h --support -s'
+            __complete_string '--help -h --support -s --yaml -y'
             return 0
         fi
 


### PR DESCRIPTION
The PR added the missing options related to yaml output only. Note that `--help` names the option as `--yaml-only` but this is not correct.
